### PR TITLE
Fix confirm modal typo and canvas clone handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -108,7 +108,7 @@ const showConfirm = (message, title = 'Confirmation') => {
             confirmModal.style.display = 'none';
             confirmModalBackdrop.style.display = 'none';
             resolve(false);
-_        };
+        };
     });
 };
 
@@ -285,8 +285,8 @@ const canvasSortable = new Sortable(canvas, {
         const newBlock = createBlockElement(blockData);
 
         // Replace the clone with the new, fully functional block
-        evt.from.insertBefore(itemEl, evt.item.nextSibling); // put the original back
-        canvas.replaceChild(newBlock, itemEl);
+        canvas.insertBefore(newBlock, itemEl);
+        canvas.removeChild(itemEl);
 
         updateCanvasPlaceholder();
     }


### PR DESCRIPTION
## Summary
- remove stray character in the confirm modal helper so the script loads correctly
- adjust SortableJS onAdd logic to replace the clone without re-inserting it into the toolbox

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69032712cd1483279f9862eae8d46c31