### PR TITLE
Fix security workflow secret scanning output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,15 +91,21 @@ jobs:
 
       - name: Check for hardcoded secrets
         run: |
-          # Check for potential hardcoded API keys
-          if grep -r "sk-[a-zA-Z0-9]\{32,\}" --exclude-dir=.git .; then
-            echo "Error: Potential hardcoded OpenAI API key found"
+          # Check for potential hardcoded API keys without echoing the secret value
+          openai_matches=$(grep -REl 'sk-[A-Za-z0-9]{32,}' --exclude-dir=.git . || true)
+          if [ -n "$openai_matches" ]; then
+            echo "Error: Potential hardcoded OpenAI API key found in the following files:"
+            printf '%s\n' "$openai_matches"
             exit 1
           fi
-          if grep -r "AIza[a-zA-Z0-9_-]\{35\}" --exclude-dir=.git .; then
-            echo "Error: Potential hardcoded Google API key found"
+
+          google_matches=$(grep -REl 'AIza[A-Za-z0-9_-]{35}' --exclude-dir=.git . || true)
+          if [ -n "$google_matches" ]; then
+            echo "Error: Potential hardcoded Google API key found in the following files:"
+            printf '%s\n' "$google_matches"
             exit 1
           fi
+
           echo "No hardcoded secrets detected"
 
       - name: Verify env template has no real keys


### PR DESCRIPTION
## Summary
- update the security workflow to capture secret-scan matches without printing raw values
- report only the filenames that triggered the scan before failing the job

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903271b2cdc8327ac4f4ee50d850c80